### PR TITLE
Fix for Stuck Deployment UI

### DIFF
--- a/Shared/Bluetooth/BluetoothManager/BluetoothManager.swift
+++ b/Shared/Bluetooth/BluetoothManager/BluetoothManager.swift
@@ -55,6 +55,7 @@ final class BluetoothManager: NSObject, ObservableObject {
     private var peripheral: CBPeripheral!
     private var txCharacteristic: CBCharacteristic!
     private var rxCharacteristic: CBCharacteristic!
+    private var dfuManager: FirmwareUpgradeManager!
     private lazy var jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .withoutEscapingSlashes
@@ -124,7 +125,7 @@ final class BluetoothManager: NSObject, ObservableObject {
         
         let bleTransport = McuMgrBleTransport(peripheral)
         bleTransport.logDelegate = logDelegate
-        let dfuManager = FirmwareUpgradeManager(transporter: bleTransport, delegate: firmwareDelegate)
+        dfuManager = FirmwareUpgradeManager(transporter: bleTransport, delegate: firmwareDelegate)
         dfuManager.logDelegate = logDelegate
 
         // Start the firmware upgrade with the image data


### PR DESCRIPTION
The UI was not getting the callbacks for .confirm, .reset and .success. We saw via debugging that the delegate was nil when these callbacks wanted to be called, so on a hunch I made this change to ensure the FirmwareUpgradeManager doesn't get released by Swift, and there we go.